### PR TITLE
Cleanup and buff interceptor

### DIFF
--- a/src/main/java/thaumicinsurgence/tileentity/TileEntityInfusionFucker.java
+++ b/src/main/java/thaumicinsurgence/tileentity/TileEntityInfusionFucker.java
@@ -61,7 +61,7 @@ public class TileEntityInfusionFucker extends TileEntity implements IAspectConta
             // Cannot copy before checking size or the moronic AspectList copy method will add a null entry
             matrixAspects = matrix.getAspects().copy();
 
-            for (Aspect aspect: matrixAspects.getAspects()) {
+            for (Aspect aspect : matrixAspects.getAspects()) {
                 // Set suction for every new aspect so essentiaEntity knows what we want
                 currentSuction = aspect;
 


### PR DESCRIPTION
Some code cleanup, but mostly a change to how the interceptor provides essentia to an infusion altar.

~Opening as a draft to get balance feedback if any, but I need to test more extensively before marking ready for review.~

Now the interceptor will attempt to provide all aspects the matrix needs in a single tick if they are available in whatever is providing essentia to the interceptor. This is mostly useful when used with an essentia provider that can see a lot of essentia in a network instead of pipes or something that will provide essentia much slower, though the functionality shouldn't be very different for other types of essentia transporters.

Overall this is a pretty large buff to interceptors, which I view as necessary as in their current form they encourage the use of an third world accelerator for infusion automation (altar, claw, and interceptor), whereas one of the goals of adding it in the first place was to remove the need to WA infusion altars.