### PR TITLE
updating the soap use tick times part 2?

### DIFF
--- a/src/main/java/thaumicinsurgence/item/ItemSanitySoapAlpha.java
+++ b/src/main/java/thaumicinsurgence/item/ItemSanitySoapAlpha.java
@@ -52,7 +52,7 @@ public class ItemSanitySoapAlpha extends ItemSanitySoap {
 
     public void onUsingTick(ItemStack stack, EntityPlayer player, int count) {
         int ticks = this.getMaxItemUseDuration(stack) - count;
-        if (ticks > 195) {
+        if (ticks > 5) {
             player.stopUsingItem();
         }
 

--- a/src/main/java/thaumicinsurgence/item/ItemSanitySoapBeta.java
+++ b/src/main/java/thaumicinsurgence/item/ItemSanitySoapBeta.java
@@ -52,7 +52,7 @@ public class ItemSanitySoapBeta extends ItemSanitySoap {
 
     public void onUsingTick(ItemStack stack, EntityPlayer player, int count) {
         int ticks = this.getMaxItemUseDuration(stack) - count;
-        if (ticks > 40) {
+        if (ticks > 2) {
             player.stopUsingItem();
         }
 


### PR DESCRIPTION
A universal gripe by players is that soap is both too expensive and too slow, while I can't change the base soap, I can reduce the use time of the advanced soaps.

I reduced the upgraded soap to 4 soap uses a second (down from the original 1 soap use per 10 seconds)
https://discord.com/channels/181078474394566657/1029918255932002395/1293025425123049493
Likewise, reduced the perm warp soap from 2 seconds to 10 soap uses a second 
https://discord.com/channels/181078474394566657/1029918255932002395/1293025382609453138

I'm open to discussions on changing the time if necessary, but lets be real, you eat these like crazy in GTNH, so this is a decent change in my opinion.