### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/thaumicinsurgence/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicinsurgence/lang/en_US.lang
@@ -46,6 +46,7 @@ tc.research_name.TI_DeliciousKromer=[[Funky]] LITTLE [[Worm]]
 tc.research_text.TI_DeliciousKromer=THIS IS [One Purchase] YOU WILL [Regret] FOR THE REST OF YOUR LIFE!
 
 #Tiles
+tile.pillarAlpha.name=Arcane Marble Pillar
 tile.arcaneMarble.name=Arcane Marble Block
 tile.arcaneMarbleBrick.name=Arcane Marble Brick
 tile.matrixAlpha.name=Arcane Marble Matrix


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.